### PR TITLE
Add runtime language switching

### DIFF
--- a/translations.py
+++ b/translations.py
@@ -1,0 +1,137 @@
+# translations.py
+
+translations = {
+    'en': {
+        'app_title': 'Excel Processor',
+        'drag_drop_text': 'Drag & Drop Excel Files Here\nor Click to Browse',
+        'select_excel_files': 'Select Excel Files',
+        'excel_files_filter': 'Excel Files (*.xlsx *.xlsm *.xls)',
+        'loaded_files': 'Loaded Files',
+        'processed_files': 'Processed Files',
+        'ready': 'Ready',
+        'header_color': 'Header Color:',
+        'clear_files': 'Clear Files',
+        'process_files': 'Process Files',
+        'processing_resumed': 'Processing resumed...',
+        'processing_paused': 'Processing paused',
+        'stopping': 'Stopping...',
+        'stop_processing_title': 'Stop Processing',
+        'stop_processing_confirm': 'Are you sure you want to stop processing?',
+        'files_loaded': '{count} files loaded',
+        'processing': 'Processing: {filename}',
+        'sheets_progress': 'Sheets: {processed}/{total}',
+        'summary': '<b>Summary:</b><br>',
+        'total_files': 'Total files: {total}<br>',
+        'success': '\u2713 Success: {count}<br>',
+        'failed': '\u2717 Failed: {count}<br>',
+        'output_folder': '<br>Output folder: <a href="{folder}">Open Deeva folder</a>',
+        'processing_stopped': 'Processing stopped by user',
+        'completed': 'Completed: {success} success, {failed} failed',
+        'menu_file': 'File',
+        'menu_clear_all': 'Clear All',
+        'menu_exit': 'Exit',
+        'menu_help': 'Help',
+        'menu_check_updates': 'Check for Updates',
+        'menu_about': 'About',
+        'menu_language': 'Language',
+        'lang_en': 'English',
+        'lang_ru': 'Русский',
+        'about_title': 'About',
+        'about_text': 'Excel Processor v{version}\n\nA tool for duplicating Excel rows with headers\n\nGitHub: https://github.com/Slipfaith/DM',
+        'update_available_title': 'Update Available',
+        'update_available_text': 'Version {latest} is available!',
+        'current_version': 'Current version: {version}',
+        'new_version': 'New version: {version}',
+        'update_prompt': 'Would you like to download and install it?',
+        'update_downloaded_title': 'Update Downloaded',
+        'update_downloaded_text': 'Update downloaded successfully!',
+        'update_restart_text': 'The application will now close to install the update.\nPlease restart the application after installation.',
+        'no_updates_title': 'No Updates',
+        'no_updates_text': 'You are using the latest version ({version})',
+        'update_error_title': 'Update Check Failed',
+        'no_exe_error': 'No executable file found in the release',
+        'auto_update_exe_only': 'Auto-update only works with compiled exe files',
+        'downloading_update': 'Downloading update...',
+        'cancel': 'Cancel',
+        'updating': 'Updating',
+        'download_failed': 'Download failed: {error}',
+        'could_not_determine': 'Could not determine latest version',
+        'error_checking_updates': 'Error checking for updates: {error}'
+    },
+    'ru': {
+        'app_title': 'Обработчик Excel',
+        'drag_drop_text': 'Перетащите файлы Excel сюда\nили нажмите для выбора',
+        'select_excel_files': 'Выберите файлы Excel',
+        'excel_files_filter': 'Файлы Excel (*.xlsx *.xlsm *.xls)',
+        'loaded_files': 'Загруженные файлы',
+        'processed_files': 'Обработанные файлы',
+        'ready': 'Готово',
+        'header_color': 'Цвет заголовка:',
+        'clear_files': 'Очистить список',
+        'process_files': 'Обработать файлы',
+        'processing_resumed': 'Обработка продолжена...',
+        'processing_paused': 'Обработка приостановлена',
+        'stopping': 'Остановка...',
+        'stop_processing_title': 'Остановить обработку',
+        'stop_processing_confirm': 'Вы уверены, что хотите остановить обработку?',
+        'files_loaded': 'Загружено файлов: {count}',
+        'processing': 'Обработка: {filename}',
+        'sheets_progress': 'Листы: {processed}/{total}',
+        'summary': '<b>Сводка:</b><br>',
+        'total_files': 'Всего файлов: {total}<br>',
+        'success': '\u2713 Успешно: {count}<br>',
+        'failed': '\u2717 Ошибок: {count}<br>',
+        'output_folder': '<br>Папка с результатами: <a href="{folder}">Открыть папку Deeva</a>',
+        'processing_stopped': 'Обработка остановлена пользователем',
+        'completed': 'Завершено: {success} успешно, {failed} с ошибками',
+        'menu_file': 'Файл',
+        'menu_clear_all': 'Очистить все',
+        'menu_exit': 'Выход',
+        'menu_help': 'Справка',
+        'menu_check_updates': 'Проверить обновления',
+        'menu_about': 'О программе',
+        'menu_language': 'Язык',
+        'lang_en': 'English',
+        'lang_ru': 'Русский',
+        'about_title': 'О программе',
+        'about_text': 'Excel Processor v{version}\n\nИнструмент для дублирования строк Excel с заголовками\n\nGitHub: https://github.com/Slipfaith/DM',
+        'update_available_title': 'Доступно обновление',
+        'update_available_text': 'Доступна версия {latest}!',
+        'current_version': 'Текущая версия: {version}',
+        'new_version': 'Новая версия: {version}',
+        'update_prompt': 'Загрузить и установить сейчас?',
+        'update_downloaded_title': 'Обновление загружено',
+        'update_downloaded_text': 'Обновление успешно загружено!',
+        'update_restart_text': 'Приложение будет закрыто для установки обновления.\nПожалуйста, перезапустите его после установки.',
+        'no_updates_title': 'Обновлений нет',
+        'no_updates_text': 'Вы используете последнюю версию ({version})',
+        'update_error_title': 'Ошибка проверки обновления',
+        'no_exe_error': 'В релизе не найден исполняемый файл',
+        'auto_update_exe_only': 'Автообновление доступно только для exe-файлов',
+        'downloading_update': 'Загрузка обновления...',
+        'cancel': 'Отмена',
+        'updating': 'Обновление',
+        'download_failed': 'Сбой загрузки: {error}',
+        'could_not_determine': 'Не удалось определить последнюю версию',
+        'error_checking_updates': 'Ошибка проверки обновлений: {error}'
+    }
+}
+
+_current_language = 'en'
+
+
+def set_language(lang: str):
+    global _current_language
+    if lang in translations:
+        _current_language = lang
+
+
+def tr(key: str, **kwargs) -> str:
+    text = translations.get(_current_language, {}).get(key,
+                     translations['en'].get(key, key))
+    if kwargs:
+        try:
+            return text.format(**kwargs)
+        except Exception:
+            return text
+    return text

--- a/updater.py
+++ b/updater.py
@@ -9,6 +9,7 @@ import tempfile
 from packaging import version
 from PySide6.QtWidgets import QMessageBox, QProgressDialog
 from PySide6.QtCore import QThread, Signal, QTimer
+from translations import tr
 
 CURRENT_VERSION = "1.1.0"
 GITHUB_API_URL = "https://api.github.com/repos/Slipfaith/DM/releases/latest"
@@ -64,7 +65,7 @@ class UpdateChecker:
             latest_version = data.get('tag_name', '').lstrip('v')
             if not latest_version:
                 if not silent:
-                    self._show_error("Could not determine latest version")
+                    self._show_error(tr('could_not_determine'))
                 return
 
             if version.parse(latest_version) > version.parse(CURRENT_VERSION):
@@ -74,7 +75,7 @@ class UpdateChecker:
 
         except Exception as e:
             if not silent:
-                self._show_error(f"Error checking for updates: {str(e)}")
+                self._show_error(tr('error_checking_updates', error=str(e)))
 
     def _show_update_available(self, latest_version, release_data):
         exe_asset = None
@@ -84,16 +85,16 @@ class UpdateChecker:
                 break
 
         if not exe_asset:
-            self._show_error("No executable file found in the release")
+            self._show_error(tr('no_exe_error'))
             return
 
         msg = QMessageBox(self.parent)
-        msg.setWindowTitle("Update Available")
-        msg.setText(f"Version {latest_version} is available!")
+        msg.setWindowTitle(tr('update_available_title'))
+        msg.setText(tr('update_available_text', latest=latest_version))
         msg.setInformativeText(
-            f"Current version: {CURRENT_VERSION}\n"
-            f"New version: {latest_version}\n\n"
-            "Would you like to download and install it?"
+            f"{tr('current_version', version=CURRENT_VERSION)}\n"
+            f"{tr('new_version', version=latest_version)}\n\n"
+            f"{tr('update_prompt')}"
         )
         msg.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
 
@@ -105,12 +106,12 @@ class UpdateChecker:
         temp_file = os.path.join(tempfile.gettempdir(), asset['name'])
 
         self.progress_dialog = QProgressDialog(
-            "Downloading update...",
-            "Cancel",
+            tr('downloading_update'),
+            tr('cancel'),
             0, 100,
             self.parent
         )
-        self.progress_dialog.setWindowTitle("Updating")
+        self.progress_dialog.setWindowTitle(tr('updating'))
         self.progress_dialog.setAutoClose(False)
         self.progress_dialog.show()
 
@@ -125,12 +126,9 @@ class UpdateChecker:
         self.progress_dialog.close()
 
         msg = QMessageBox(self.parent)
-        msg.setWindowTitle("Update Downloaded")
-        msg.setText("Update downloaded successfully!")
-        msg.setInformativeText(
-            "The application will now close to install the update.\n"
-            "Please restart the application after installation."
-        )
+        msg.setWindowTitle(tr('update_downloaded_title'))
+        msg.setText(tr('update_downloaded_text'))
+        msg.setInformativeText(tr('update_restart_text'))
         msg.setStandardButtons(QMessageBox.Ok)
         msg.exec()
 
@@ -138,7 +136,7 @@ class UpdateChecker:
 
     def _on_download_error(self, error):
         self.progress_dialog.close()
-        self._show_error(f"Download failed: {error}")
+        self._show_error(tr('download_failed', error=error))
 
     def _install_update(self, new_exe_path):
         current_exe = sys.executable
@@ -177,18 +175,18 @@ except Exception as e:
 
             QTimer.singleShot(100, self.parent.close)
         else:
-            self._show_error("Auto-update only works with compiled exe files")
+            self._show_error(tr('auto_update_exe_only'))
 
     def _show_no_updates(self):
         QMessageBox.information(
             self.parent,
-            "No Updates",
-            f"You are using the latest version ({CURRENT_VERSION})"
+            tr('no_updates_title'),
+            tr('no_updates_text', version=CURRENT_VERSION)
         )
 
     def _show_error(self, error_message):
         QMessageBox.warning(
             self.parent,
-            "Update Check Failed",
+            tr('update_error_title'),
             error_message
         )


### PR DESCRIPTION
## Summary
- support English and Russian strings via new `translations` module
- integrate translation into GUI and allow runtime switching
- localize updater messages

## Testing
- `python -m py_compile *.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68894b35cff0832ca2aaec8f27f7c5cd