### PR TITLE
Add image preview on error dialog thumbnails

### DIFF
--- a/translations.py
+++ b/translations.py
@@ -84,6 +84,7 @@ translations = {
         'attach_image': 'Attach Image',
         'select_images': 'Select Images',
         'info': 'Information',
+        'image_preview': 'Image Preview',
         'max_attachments': 'Maximum 5 attachments allowed',
         'images_attached': 'images'
     },
@@ -170,6 +171,7 @@ translations = {
         'attach_image': 'Прикрепить изображение',
         'select_images': 'Выберите изображения',
         'info': 'Информация',
+        'image_preview': 'Просмотр изображения',
         'max_attachments': 'Максимум 5 вложений',
         'images_attached': 'изображений'
     }


### PR DESCRIPTION
## Summary
- add `ImagePreviewDialog` to display scaled image previews
- open preview when clicking thumbnail (outside delete button)
- localize new `image_preview` string in Russian and English translations

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b434f5f4c832ca73549b16e7a8df9