### PR TITLE
Update send button style

### DIFF
--- a/error_dialog.py
+++ b/error_dialog.py
@@ -289,6 +289,7 @@ class ErrorReportDialog(QDialog):
 
         self.send_btn = QPushButton("📤")  # Send icon
         self.send_btn.setObjectName("telegramButton")
+        self.send_btn.setFixedSize(44, 44)
         self.send_btn.clicked.connect(self.send_report)
 
         self.cancel_btn = QPushButton(tr('cancel'))
@@ -496,6 +497,7 @@ class FeedbackDialog(QDialog):
 
         self.send_btn = QPushButton("📤")  # Send icon
         self.send_btn.setObjectName("telegramButton")
+        self.send_btn.setFixedSize(44, 44)
         self.send_btn.clicked.connect(self.send_feedback)
 
         self.cancel_btn = QPushButton(tr('cancel'))

--- a/styles.py
+++ b/styles.py
@@ -252,4 +252,22 @@ QGroupBox {
     color: #666666;
     font-size: 12px;
 }
+
+#telegramButton {
+    background-color: #ffffff;
+    border: 1px solid #d0d0d0;
+    border-radius: 6px;
+    font-size: 24px;
+    min-width: 44px;
+    min-height: 44px;
+}
+
+#telegramButton:hover {
+    background-color: #f0f0f0;
+    border-color: #b3b3b3;
+}
+
+#telegramButton:pressed {
+    background-color: #e0e0e0;
+}
 """


### PR DESCRIPTION
## Summary
- style Error Report dialog send button square with large emoji
- apply same style in feedback dialog
- add Telegram button style in stylesheet

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b47707dcc832cac462105b0363671