### PR TITLE
Shrink ErrorReport buttons

### DIFF
--- a/error_dialog.py
+++ b/error_dialog.py
@@ -288,11 +288,11 @@ class ErrorReportDialog(QDialog):
         buttons_layout = QHBoxLayout()
         self.send_btn = QPushButton("📤")  # Send icon
         self.send_btn.setObjectName("telegramButton")
-        self.send_btn.setFixedSize(36, 36)
+        self.send_btn.setFixedSize(32, 32)
         self.send_btn.clicked.connect(self.send_report)
         self.cancel_btn = QPushButton("❌")  # Cancel icon
         self.cancel_btn.setObjectName("telegramButton")
-        self.cancel_btn.setFixedSize(36, 36)
+        self.cancel_btn.setFixedSize(32, 32)
         self.cancel_btn.clicked.connect(self.reject)
         buttons_layout.addStretch()
         buttons_layout.addWidget(self.send_btn)
@@ -494,12 +494,12 @@ class FeedbackDialog(QDialog):
 
         self.send_btn = QPushButton("📤")  # Send icon
         self.send_btn.setObjectName("telegramButton")
-        self.send_btn.setFixedSize(36, 36)
+        self.send_btn.setFixedSize(32, 32)
         self.send_btn.clicked.connect(self.send_feedback)
 
         self.cancel_btn = QPushButton("❌")  # Cancel icon
         self.cancel_btn.setObjectName("telegramButton")
-        self.cancel_btn.setFixedSize(36, 36)
+        self.cancel_btn.setFixedSize(32, 32)
         self.cancel_btn.clicked.connect(self.reject)
 
         buttons_layout.addStretch()

--- a/styles.py
+++ b/styles.py
@@ -258,8 +258,8 @@ QGroupBox {
     border: 1px solid #d0d0d0;
     border-radius: 6px;
     font-size: 20px;
-    min-width: 36px;
-    min-height: 36px;
+    min-width: 32px;
+    min-height: 32px;
 }
 
 #telegramButton:hover {


### PR DESCRIPTION
## Summary
- tweak sizes for send/cancel buttons in ErrorReportDialog
- adjust `#telegramButton` style to use 32px dimensions

## Testing
- `python -m py_compile error_dialog.py styles.py`


------
https://chatgpt.com/codex/tasks/task_e_688b5de1bda8832c8c9718ff0587b36a