### PR TITLE
Add GPG signature verification for updater

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ PySide6>=6.5.0
 pywin32>=305
 openpyxl>=3.1.0
 packaging>=23.0
+pgpy>=0.6.0

--- a/updater.py
+++ b/updater.py
@@ -7,6 +7,7 @@ import sys
 import subprocess
 import tempfile
 import hashlib
+import types
 from packaging import version
 from PySide6.QtWidgets import QMessageBox, QProgressDialog
 from PySide6.QtCore import QThread, Signal, QTimer
@@ -14,6 +15,60 @@ from translations import tr
 
 CURRENT_VERSION = "1.2.0"
 GITHUB_API_URL = "https://api.github.com/repos/Slipfaith/DM/releases/latest"
+
+PUBLIC_KEY = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBGiOgpwBEADWe0sD6MHg/dGUucbX38IfOrRitHlLyxJOVA6txBRVOsjBbS87
+qqA/Wis7zGZj7Rvx7VJbXwE4MKwIFYZP3g4wQFBDSHT3aRwpWO4edPPf5wTvV8Ya
+UrCLAOcpm5142xxRS3oKx9wksnhdy2rE/BUWB2L5syhBzzyB8cWZLKL/uj9VLwoM
+aNCjfY90ADgWrK9iOA9vcYu1TLtRoKeK/VJPPQz2Hx5ssHQrWcgIBoI2pDvZ5E2A
+6DpEfobPRMoazgbqeNAYFebhh83bYFyFQPm3L4HdhRGG7hvFnITMZrN73mnqVOFo
+/m9ptepZfizDrkCQhWg0sSZHwtDPWtgm5lzLPLYsj+ubBzn7wgLsxqrSRhQkDQkp
+yK9Jw9h/0BhftvqQhtF7Ujr4rDgtR8y00kzsKUb09akd2Bn6pDbjvi6SjstHo0IT
+SPQxfl2c5JgOhyNdUZTWcdFaCKOPZvxFirerivOHwFmjIQR3xEWneUZkLzfx/+mW
+ODC09aby2qjg9fFT6JCvGlS+R1jc9aZBbaZ9pBxkNxy2Y0R1BLgn+/q1Nz0gucx3
+WxFbpHMTRfgwwSoOfaj0nmFDCQhKedpf/xk6A1P+heY3aiJKPkF3kxKKsRFuGXRQ
+fZMrt/JtlRr93FV0YHiS4dV3iUNk8x/zwlb4ZFeWGbKrnXOghoRDEu+fSwARAQAB
+tCNzbGlwZmFpdGggKGFwcHMpIDxzbGlwZmFpdEBtYWlsLnJ1PokCUQQTAQgAOxYh
+BGBXnHEj/5OvQcsN7E9LxTuAU6dJBQJojoKcAhsDBQsJCAcCAiICBhUKCQgLAgQW
+AgMBAh4HAheAAAoJEE9LxTuAU6dJLUQP/i+5qMPJ3Czx5f1+6490WG6O3lWXOJ77
+FP8saIzZEgGzaEXgLiq2QHZHtCHHbYGQCXCv7a0POZ1v9eV6lYMLnnuJcmCYGmCO
+bEm+8RksZJOsY8aWyWG1d7FPyVTB0b5/5454JztdanJZBHh0ry/k7LcHUyO6E98t
+NoSkUS+S1hNjMvCF/cw2hnvABfVcfc5qSjvbgx5HB5R9M8DKkV4FO33uYYEjjQJc
+acNpruAV+bmfq15xAfwOMggQqh8nwlJlk91hzEjQWcxvjB5rk2Ogp8HQNn1mhhVM
+5GF6EH0ijtDh1L2YeAaAmq1kP/3C/aWC98P+EnchLhK4lzP8u1lgq2eRvfVVlTsf
+PMPuLQw5mA/O0j2O9bjCGW8araRQzqqz8HP/Y9t3JlaQM5NLZgRsOfNIU2rJcb5+
+cQu5+yclc3/yRAEd9LfxSbQrm/99VDofGIDTfNXTkHFefT75TINmNB1OGVNBOr0D
+LJ1Yz/9x2ho5XZK+S0wlumH/8BPptjVKEgKQzFQ0iftAj3yqtgur36U1sTAttL9M
+Q//rGUmR2E4QDEJUxNCpwxOBtBa3JAubBq4PlWTj9/u3zMumEs0dveb4ESR68old
+rLKYqW/ypbMKg7GC6CXkuGhqoDxcjyiFFf7P1I4EZjjyF/n6z1V6EGHKNBvl2zY3
+Bx4/2kFQYzxFuQINBGiOgpwBEADZZtVKarOnXALbNNzWo0pEAwolaglGmrfuV8iP
+h7Qt36IGPco5Ouj/QNfQGCivxcRelZAK6MQXk2JTcZNUGueEeunl2uq5zjI+wNYl
++rXJMQtKSa92lwjoQuyC/51XJbblTEaXESGV7JCqPU3zoE7JUl7XubM8ulC5cbRR
+cNdZ45fClZrytuepBkhc8pn0Lvkkpk77j8F7RvbEYhi1rDlmwmaMcQqK7z0UEpoT
+rFnyageuJys+wgN8aLk4L+z37+WcscN1o5U10czCrRH7jgqMBO093lnVjZIq7leq
+lWhZ6vVH0zXdlu+cjER1uQNtsqkuwoVZd9z7P21drNma+/pl7NuzKey9XwAnmwQ7
+XvCAie2qUhdDyPzd9l6rGcTJQ4NZu6eyFhxHOgLe+jL7Qn4UikKpWMQnrddLw0wK
+GvP51T1HsGTFtcKcppJ8qzth9CEe0K6KhT4s89X2KS/4CzpawWQdFkvP8NUL5rVp
+MYSZCtrTE33uDoeb2u/5nGxFcjpGNuLsScAuN910LSJQd4JZTpnwAI6TGkp86o/e
+t8N9Yho/ySWpRqP1svPHk7P12147GAAVxcwf2I+eycKPzDLyIkrDyNsLvHvuXZxL
+zikxIgnwEgtNg6WMGfd5gu4YgRnLPWzBeLrjGjBcRWK0MoDDZveXSzfYfet0jB6e
+hbzktwARAQABiQI2BBgBCAAgFiEEYFeccSP/k69Byw3sT0vFO4BTp0kFAmiOgpwC
+GwwACgkQT0vFO4BTp0nLUBAAqftW16m9iUKvBfOIdeAGUCkPSlPy2K7bW1amQQxf
+oWFiAk1I4Nb95BM35ucBk7C9kQBaHXvpDp/ZOAqpAnhLTiJN+9N7RaFxx63/YlNr
+EH5XnfFhAmTEt8mnSejqSLemomgd1uDw5FijFf0O8REZgsTSJxeJe0LhOygFVv1e
+JAatvwjQgHyvtp+Z2CDLw9NpUQ+RDakdXK9z8+LsIhzAXtRLxTrhZwrJ4ZUoLUVs
+BWVaJePchCP6n+++44W4jFEkfHCefzio7Gsmr79jR5+IltGbSfgCQO1MGfECPHo2
+u1UmkW3jpxoZuZdVvXJbXI2wq363A2xdQSVhn0QRvWjQVTc3AXBnywV7JUQpb5uZ
+rK9bBxoCIRO7F+i7eXRM3hopYtke6DYBxQ/nDN0i98/NsmASOfuz5NpLIyLv5JW3
+KtnLi71Nmi5SI2kS87gMLuI4JpqviYSu4Oj5W2sUlTfXWnd8LTQ/MKXnN2ilahII
+g47aAZgX28v3nYjhfHmlG22gBhyCqp0+E613iP7EmHy3YHceuJoCQdzuMOfezYix
+huSF7SmgYAEYqhTZoXRbaRG5eWOkjMMFPxTDf68/tlj6HdKvBggqbl/fPErJjHmF
+G8cDlVE3F/Dr26M+j3U/pIn2uzAoU1vuukI+qsd9bd7B46i790XBwnC/NPzllsYv
+0c8=
+=ohJm
+-----END PGP PUBLIC KEY BLOCK-----
+"""
 
 
 class DownloadThread(QThread):
@@ -59,6 +114,7 @@ class UpdateChecker:
         self.download_thread = None
         self.release_data = None
         self.current_asset = None
+        self.signature_asset = None
 
     def check_for_updates(self, silent=False):
         try:
@@ -83,15 +139,22 @@ class UpdateChecker:
     def _show_update_available(self, latest_version, release_data):
         exe_asset = None
         hash_asset = None
+        sig_asset = None
 
         for asset in release_data.get('assets', []):
             if asset['name'].endswith('.exe'):
                 exe_asset = asset
             elif asset['name'].endswith('.exe.sha256'):
                 hash_asset = asset
+            elif asset['name'].endswith('.exe.asc'):
+                sig_asset = asset
 
         if not exe_asset:
             self._show_error(tr('no_exe_error'))
+            return
+
+        if not sig_asset:
+            self._show_error("No signature file found for verification.")
             return
 
         if not hash_asset:
@@ -117,6 +180,7 @@ class UpdateChecker:
         if msg.exec() == QMessageBox.Yes:
             self.release_data = release_data
             self.current_asset = exe_asset
+            self.signature_asset = sig_asset
             self._download_update(exe_asset)
 
     def _download_update(self, asset):
@@ -142,6 +206,22 @@ class UpdateChecker:
 
     def _on_download_finished(self, file_path):
         self.progress_dialog.close()
+
+        sig_path = file_path + '.asc'
+        try:
+            with urllib.request.urlopen(self.signature_asset['browser_download_url']) as response, open(sig_path, 'wb') as f:
+                f.write(response.read())
+            self.verify_signature(file_path, sig_path)
+        except Exception as e:
+            if os.path.exists(file_path):
+                os.remove(file_path)
+            if os.path.exists(sig_path):
+                os.remove(sig_path)
+            QMessageBox.critical(self.parent, "Signature Verification Failed", str(e))
+            return
+        finally:
+            if os.path.exists(sig_path):
+                os.remove(sig_path)
 
         # Try to download and verify hash
         hash_verified = False
@@ -203,6 +283,53 @@ class UpdateChecker:
             )
 
         return True
+
+    def verify_signature(self, file_path, sig_path):
+        try:
+            with tempfile.TemporaryDirectory() as gnupg_home:
+                env = os.environ.copy()
+                env['GNUPGHOME'] = gnupg_home
+                with tempfile.NamedTemporaryFile('w', delete=False, suffix='.asc') as key_file:
+                    key_file.write(PUBLIC_KEY)
+                    key_path = key_file.name
+                try:
+                    subprocess.run(
+                        ['gpg', '--import', key_path],
+                        check=True,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        env=env
+                    )
+                    subprocess.run(
+                        ['gpg', '--verify', sig_path, file_path],
+                        check=True,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        env=env
+                    )
+                    return True
+                finally:
+                    os.remove(key_path)
+        except Exception:
+            self._verify_with_pgpy(file_path, sig_path)
+
+    def _verify_with_pgpy(self, file_path, sig_path):
+        try:
+            try:
+                import imghdr  # noqa: F401
+            except ModuleNotFoundError:
+                mod = types.ModuleType('imghdr')
+                mod.what = lambda *args, **kwargs: None
+                sys.modules['imghdr'] = mod
+            from pgpy import PGPKey, PGPSignature
+            pubkey, _ = PGPKey.from_blob(PUBLIC_KEY)
+            sig = PGPSignature.from_file(sig_path)
+            with open(file_path, 'rb') as f:
+                data = f.read()
+            if not pubkey.verify(data, sig):
+                raise Exception('Invalid signature')
+        except Exception as e:
+            raise Exception(f'PGPy verification failed: {e}')
 
     def _install_update(self, new_exe_path):
         current_exe = sys.executable


### PR DESCRIPTION
## Summary
- embed maintainer's public key for update verification
- verify downloaded executables via GPG, falling back to PGPy
- require `pgpy` for signature verification

## Testing
- `python -m py_compile updater.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pywin32>=305)*

------
https://chatgpt.com/codex/tasks/task_e_688f8e6c7230832c98451a4cd783e139