### PR TITLE
Fix extra header insertion in excel processor

### DIFF
--- a/excel_processor.vbs
+++ b/excel_processor.vbs
@@ -122,6 +122,14 @@ Sub RestructureSheet(sheet, headerRange)
             row = row + 1
         End If
     Loop
+    ' Remove extra header if it was added at the end of the sheet
+    Set usedRange = sheet.UsedRange
+    lastRow = usedRange.Row + usedRange.Rows.Count - 1
+    If lastRow > headerRow Then
+        If sheet.Cells(lastRow, startCol).Interior.Color = headerRange.Cells(1, 1).Interior.Color Then
+            sheet.Rows(lastRow).Delete
+        End If
+    End If
     sheet.Application.CutCopyMode = False
     sheet.Rows(headerRow).RowHeight = headerHeight
 End Sub


### PR DESCRIPTION
## Summary
- remove trailing header row left by Excel restructuring logic

## Testing
- `cscript //NoLogo excel_processor.vbs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b56d61df9c832c99e3104372e5f074