### PR TITLE
Skip hidden rows during Excel processing

### DIFF
--- a/excel_processor.py
+++ b/excel_processor.py
@@ -89,6 +89,8 @@ class ExcelProcessor:
         if self.config.header_color:
             self.logger.debug(f"Searching for header with color: {self.config.header_color}")
             for row in range(1, min(20, used_range.Rows.Count + 1)):
+                if sheet.Rows(row).Hidden:
+                    continue
                 for col in range(1, used_range.Columns.Count + 1):
                     cell = sheet.Cells(row, col)
                     cell_color = cell.Interior.Color
@@ -121,6 +123,8 @@ class ExcelProcessor:
         return None
 
     def _has_formulas(self, sheet, row, start_col, end_col):
+        if sheet.Rows(row).Hidden:
+            return False
         for col in range(start_col, end_col + 1):
             cell = sheet.Cells(row, col)
             if cell.HasFormula:
@@ -128,6 +132,8 @@ class ExcelProcessor:
         return False
 
     def _has_data_in_range(self, sheet, row, start_col, end_col):
+        if sheet.Rows(row).Hidden:
+            return False
         for col in range(start_col, end_col + 1):
             if sheet.Cells(row, col).Value:
                 return True
@@ -147,11 +153,17 @@ class ExcelProcessor:
         row = header_row + 1
 
         while row <= last_row:
+            if sheet.Rows(row).Hidden:
+                row += 1
+                continue
+
             if self._has_data_in_range(sheet, row, header_start_col, header_end_col):
                 block = {'start_row': row, 'end_row': row}
 
-                if row + 1 <= last_row and self._has_formulas(sheet, row + 1, header_start_col, header_end_col):
-                    block['end_row'] = row + 1
+                next_row = row + 1
+                if next_row <= last_row and not sheet.Rows(next_row).Hidden and \
+                        self._has_formulas(sheet, next_row, header_start_col, header_end_col):
+                    block['end_row'] = next_row
                     row += 2
                 else:
                     row += 1

--- a/excel_processor_v2.py
+++ b/excel_processor_v2.py
@@ -19,6 +19,8 @@ class ExcelProcessorV2:
         yellow_headers_count = 0
 
         for row in range(1, min(50, used_range.Rows.Count + 1)):
+            if sheet.Rows(row).Hidden:
+                continue
             for col in range(1, min(10, used_range.Columns.Count + 1)):
                 cell = sheet.Cells(row, col)
                 if cell.Interior.Color == self.config.header_color and cell.Value:
@@ -62,6 +64,10 @@ class ExcelProcessorV2:
         cols_count = used_range.Columns.Count
 
         while current_row <= last_row:
+            if sheet.Rows(current_row).Hidden:
+                current_row += 1
+                continue
+
             is_header = False
             for col in range(1, min(10, cols_count + 1)):
                 cell = sheet.Cells(current_row, col)
@@ -79,6 +85,10 @@ class ExcelProcessorV2:
                 current_group = []
 
                 while current_row <= last_row:
+                    if sheet.Rows(current_row).Hidden:
+                        current_row += 1
+                        continue
+
                     is_next_header = False
                     for col in range(1, min(10, cols_count + 1)):
                         if sheet.Cells(current_row, col).Interior.Color == self.config.header_color and sheet.Cells(
@@ -161,7 +171,7 @@ class ExcelProcessorV2:
         try:
             for shape in sheet.Shapes:
                 shape_row = shape.TopLeftCell.Row
-                if start_row <= shape_row <= end_row:
+                if start_row <= shape_row <= end_row and not sheet.Rows(shape_row).Hidden:
                     row_offset = shape_row - start_row
 
                     shape.Copy()


### PR DESCRIPTION
## Summary
- ignore hidden Excel rows when searching for headers or duplicating data
- bypass hidden rows in V2 block detection and skip shapes on hidden rows

## Testing
- `pytest -q`
- `python -m py_compile excel_processor.py excel_processor_v2.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5759ee244832cac03534a8d38668d