### PR TITLE
Handle image duplication in Excel processors

### DIFF
--- a/excel_processor_v2.py
+++ b/excel_processor_v2.py
@@ -169,7 +169,9 @@ class ExcelProcessorV2:
 
     def _copy_shapes_in_range(self, sheet, start_row, end_row, target_start_row):
         try:
-            for shape in sheet.Shapes:
+            shapes_count = sheet.Shapes.Count
+            for idx in range(1, shapes_count + 1):
+                shape = sheet.Shapes(idx)
                 shape_row = shape.TopLeftCell.Row
                 if start_row <= shape_row <= end_row and not sheet.Rows(shape_row).Hidden:
                     row_offset = shape_row - start_row


### PR DESCRIPTION
## Summary
- copy shapes when duplicating blocks and headers in `excel_processor`
- iterate over original shape collection in `excel_processor_v2` to paste images only once

## Testing
- `python -m py_compile excel_processor.py excel_processor_v2.py`


------
https://chatgpt.com/codex/tasks/task_e_68b59ca3b7e4832c8a2942956f70ca51