### PR TITLE
Prevent duplicate shapes during Excel processing

### DIFF
--- a/excel_processor.py
+++ b/excel_processor.py
@@ -242,19 +242,33 @@ class ExcelProcessor:
 
     def _copy_shapes_in_range(self, sheet, start_row, end_row, target_start_row):
         try:
+            target_end_row = target_start_row + (end_row - start_row)
+
             shapes_count = sheet.Shapes.Count
+            existing_positions = set()
+
+            for idx in range(1, shapes_count + 1):
+                shape = sheet.Shapes(idx)
+                shape_row = shape.TopLeftCell.Row
+                if target_start_row <= shape_row <= target_end_row:
+                    existing_positions.add((round(shape.Left, 2), round(shape.Top, 2)))
+
             for idx in range(1, shapes_count + 1):
                 shape = sheet.Shapes(idx)
                 shape_row = shape.TopLeftCell.Row
                 if start_row <= shape_row <= end_row and not sheet.Rows(shape_row).Hidden:
                     row_offset = shape_row - start_row
-
+                    target_cell = sheet.Cells(target_start_row + row_offset, shape.TopLeftCell.Column)
+                    new_top = target_cell.Top + (shape.Top - shape.TopLeftCell.Top)
+                    new_left = target_cell.Left + (shape.Left - shape.TopLeftCell.Left)
+                    pos_key = (round(new_left, 2), round(new_top, 2))
+                    if pos_key in existing_positions:
+                        continue
                     shape.Copy()
                     sheet.Paste()
-
                     new_shape = sheet.Shapes(sheet.Shapes.Count)
-                    target_cell = sheet.Cells(target_start_row + row_offset, shape.TopLeftCell.Column)
-                    new_shape.Top = target_cell.Top + (shape.Top - shape.TopLeftCell.Top)
-                    new_shape.Left = target_cell.Left + (shape.Left - shape.TopLeftCell.Left)
+                    new_shape.Top = new_top
+                    new_shape.Left = new_left
+                    existing_positions.add(pos_key)
         except Exception as e:
             self.logger.warning(f"Error copying shapes: {e}")


### PR DESCRIPTION
## Summary
- avoid copying shapes twice when duplicating rows in Excel sheets

## Testing
- `python -m py_compile excel_processor.py excel_processor_v2.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5a82f8d90832c979e70233306b32f