### PR TITLE
Fix duplicate image insertion when duplicating Excel rows

### DIFF
--- a/excel_processor.py
+++ b/excel_processor.py
@@ -244,14 +244,15 @@ class ExcelProcessor:
         try:
             target_end_row = target_start_row + (end_row - start_row)
 
-            shapes_count = sheet.Shapes.Count
-            existing_positions = set()
-
-            for idx in range(1, shapes_count + 1):
+            # If shapes already exist in the target range, skip copying to avoid duplicates
+            for idx in range(1, sheet.Shapes.Count + 1):
                 shape = sheet.Shapes(idx)
                 shape_row = shape.TopLeftCell.Row
                 if target_start_row <= shape_row <= target_end_row:
-                    existing_positions.add((round(shape.Left, 2), round(shape.Top, 2)))
+                    return
+
+            shapes_count = sheet.Shapes.Count
+            existing_positions = set()
 
             for idx in range(1, shapes_count + 1):
                 shape = sheet.Shapes(idx)


### PR DESCRIPTION
## Summary
- Prevent images from being copied twice when restructuring sheets by skipping shape copy if the target already contains shapes.

## Testing
- `python -m py_compile excel_processor.py excel_processor_v2.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5b98c0890832c85241a384d624fcc