### PR TITLE
Fix duplicate images when processing Excel sheets

### DIFF
--- a/excel_processor.py
+++ b/excel_processor.py
@@ -243,15 +243,14 @@ class ExcelProcessor:
     def _copy_shapes_in_range(self, sheet, start_row, end_row, target_start_row):
         try:
             target_end_row = target_start_row + (end_row - start_row)
-
-            shapes_count = sheet.Shapes.Count
-            existing_positions = []
-
-            for idx in range(1, shapes_count + 1):
+            for idx in range(sheet.Shapes.Count, 0, -1):
                 shape = sheet.Shapes(idx)
                 shape_row = shape.TopLeftCell.Row
                 if target_start_row <= shape_row <= target_end_row:
-                    existing_positions.append((shape.Left, shape.Top))
+                    shape.Delete()
+
+            shapes_count = sheet.Shapes.Count
+            existing_positions = []
 
             def _position_exists(left, top):
                 for ex_left, ex_top in existing_positions:

--- a/excel_processor_v2.py
+++ b/excel_processor_v2.py
@@ -170,13 +170,11 @@ class ExcelProcessorV2:
     def _copy_shapes_in_range(self, sheet, start_row, end_row, target_start_row):
         try:
             target_end_row = target_start_row + (end_row - start_row)
-
-            # If shapes already exist in the target range, skip copying to avoid duplicates
-            for idx in range(1, sheet.Shapes.Count + 1):
+            for idx in range(sheet.Shapes.Count, 0, -1):
                 shape = sheet.Shapes(idx)
                 shape_row = shape.TopLeftCell.Row
                 if target_start_row <= shape_row <= target_end_row:
-                    return
+                    shape.Delete()
 
             shapes_count = sheet.Shapes.Count
             existing_positions = set()


### PR DESCRIPTION
## Summary
- Delete shapes in target rows before copying to avoid duplicated images during processing
- Apply same clean-up for V2 processor to ensure accurate shape duplication

## Testing
- `python -m py_compile excel_processor.py excel_processor_v2.py`

------
https://chatgpt.com/codex/tasks/task_e_68b5cd8eb7ec832cba91bda59400f9bf