### PR TITLE
Ensure VBScript errors output in English

### DIFF
--- a/excel_processor.py
+++ b/excel_processor.py
@@ -27,6 +27,7 @@ class ExcelProcessor:
             cmd = [
                 "cscript",
                 "//nologo",
+                "//U",
                 str(script_path),
                 str(output_file),
                 str(self.config.header_color),
@@ -38,6 +39,7 @@ class ExcelProcessor:
                     check=True,
                     capture_output=True,
                     text=True,
+                    encoding="utf-16",
                 )
             except subprocess.CalledProcessError as exc:
                 stderr = exc.stderr.strip() if exc.stderr else str(exc)

--- a/excel_processor.vbs
+++ b/excel_processor.vbs
@@ -1,4 +1,7 @@
 Option Explicit
+' Force English locale so all error messages are returned in English.
+SetLocale 1033
+
 Dim filePath, headerColor
 If WScript.Arguments.Count < 2 Then
     WScript.StdErr.WriteLine "Usage: cscript excel_processor.vbs <file> <header_color>"


### PR DESCRIPTION
## Summary
- Force VBScript to use English locale to guarantee English error descriptions.
- Run cscript in Unicode mode and decode stderr/stdout as UTF-16 so messages display correctly.

## Testing
- `python -m py_compile excel_processor.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6b15399ec832c8a93d297f7344086