### PR TITLE
Skip hidden rows during Excel processing

### DIFF
--- a/excel_processor_v2.py
+++ b/excel_processor_v2.py
@@ -19,6 +19,8 @@ class ExcelProcessorV2:
         yellow_headers_count = 0
 
         for row in range(1, min(50, used_range.Rows.Count + 1)):
+            if sheet.Rows(row).Hidden:
+                continue
             for col in range(1, min(10, used_range.Columns.Count + 1)):
                 cell = sheet.Cells(row, col)
                 if cell.Interior.Color == self.config.header_color and cell.Value:
@@ -62,6 +64,9 @@ class ExcelProcessorV2:
         cols_count = used_range.Columns.Count
 
         while current_row <= last_row:
+            if sheet.Rows(current_row).Hidden:
+                current_row += 1
+                continue
             is_header = False
             for col in range(1, min(10, cols_count + 1)):
                 cell = sheet.Cells(current_row, col)
@@ -79,6 +84,9 @@ class ExcelProcessorV2:
                 current_group = []
 
                 while current_row <= last_row:
+                    if sheet.Rows(current_row).Hidden:
+                        current_row += 1
+                        continue
                     is_next_header = False
                     for col in range(1, min(10, cols_count + 1)):
                         if sheet.Cells(current_row, col).Interior.Color == self.config.header_color and sheet.Cells(
@@ -161,6 +169,8 @@ class ExcelProcessorV2:
         try:
             for shape in sheet.Shapes:
                 shape_row = shape.TopLeftCell.Row
+                if sheet.Rows(shape_row).Hidden:
+                    continue
                 if start_row <= shape_row <= end_row:
                     row_offset = shape_row - start_row
 


### PR DESCRIPTION
## Summary
- ignore hidden rows when detecting headers and data blocks
- skip hidden rows and shapes during enhanced Excel processing

## Testing
- `python -m py_compile excel_processor.py excel_processor_v2.py && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68b6d3a9b1c8832cbe1bd4b179059a71